### PR TITLE
Fixed error handling

### DIFF
--- a/.aws/task-def-note-server-dev.json
+++ b/.aws/task-def-note-server-dev.json
@@ -20,7 +20,14 @@
                 }
             },
             "essential": true,
-            "entryPoint": [],
+            "entryPoint": [
+                "-p",
+                "80",
+                "-P",
+                "dev",
+                "-b",
+                "sksmithnotes"
+            ],
             "command": [],
             "environment": [],
             "environmentFiles": [],

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -10,7 +10,7 @@ env:
   ECR_REPOSITORY: note-server
   ECS_SERVICE: NoteServerDev
   ECS_CLUSTER: Dev-Cluster
-  ECS_TASK_DEFINITION: .aws/task-def.json
+  ECS_TASK_DEFINITION: .aws/task-def-note-server-dev.json
   CONTAINER_NAME: note-server
 
 jobs:
@@ -24,10 +24,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Set Build Variables
         run: |
-          echo "PROF=dev" >> $GITHUB_ENV
           echo "VER=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_ENV
           echo "SHA1=$(echo $GITHUB_SHA | cut -c 1-6)" >> $GITHUB_ENV
           echo "NOW=$(date -u +'%Y-%m-%d_%TZ')" >> $GITHUB_ENV
+    
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1 # TODO Use this repositories preferred method of auth
         with:
@@ -46,7 +46,7 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
         run: |
           # Build a docker container and push it to ECR so that it can be deployed to ECS.
-          docker build --build-arg VER=${{ env.VER }} --build-arg SHA1=${{ env.SHA1 }} --build-arg NOW=${{ env.NOW }} --build-arg PROF=${{ env.PROF }} -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker build --build-arg VER=${{ env.VER }} --build-arg SHA1=${{ env.SHA1 }} --build-arg NOW=${{ env.NOW }} -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.29
+          version: v1.43
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,11 @@ COPY . .
 ARG VER=NOT_SUPPLIED
 ARG SHA1=NOT_SUPPLIED
 ARG NOW=NOT_SUPPLIED
-ARG PROF=NOT_SUPPLIED
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
     -ldflags "-X github.com/sksmith/note-server/config.AppVersion=$VER \
-    		-X github.com/sksmith/note-server/config.Sha1Version=$SHA1 \
-		    -X github.com/sksmith/note-server/config.BuildTime=$NOW \
-            -X github.com/sksmith/note-server/config.Profile=$PROF" \
+    -X github.com/sksmith/note-server/config.Sha1Version=$SHA1 \
+    -X github.com/sksmith/note-server/config.BuildTime=$NOW \
     -o ./note-server ./cmd
 
 RUN apk add --update ca-certificates

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,16 @@ VER := $(shell git describe --tag)
 SHA1 := $(shell git rev-parse HEAD)
 NOW := $(shell date -u +'%Y-%m-%d_%TZ')
 
+check:
+	@echo Linting
+	golangci-lint run
+
+	@echo Security scanning
+	gosec ./...
+
+	@echo Testing
+	go test ./...
+
 build:
 	@echo Building the binary
 	go build -ldflags "-X github.com/sksmith/note-server/config.AppVersion=$(VER)\
@@ -21,3 +31,7 @@ docker:
 	docker build \
 		--build-arg VER=$(VER) \
 		--build-arg SHA1=$(SHA1) \port
+
+tools:
+	go install github.com/securego/gosec/v2/cmd/gosec@latest
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0

--- a/README.md
+++ b/README.md
@@ -22,6 +22,24 @@ make build
 ./bin/note-server
 ```
 
+For doing local development, you'll want linting, and security tooling. Run this to install them.
+
+```shell
+make tools
+```
+
+To run the linter, security check, and tests:
+
+```shell
+make check
+```
+
+To just run the tests alone:
+
+```shell
+make test
+```
+
 ## Setting Up AWS
 
 I have quite a bit in this project automated. Linting, security, and unit testing all execute as

--- a/api/note_test.go
+++ b/api/note_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/sksmith/note-server/api"
+	"github.com/sksmith/note-server/core"
 	"github.com/sksmith/note-server/core/note"
 )
 
@@ -27,23 +28,39 @@ func TestGet(t *testing.T) {
 	}
 }
 
-// TODO see issue 5
-// func TestGetError(t *testing.T) {
-// 	r := httptest.NewRequest(http.MethodGet, "/1", nil)
-// 	w := httptest.NewRecorder()
+func TestGetInternalServerError(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/1", nil)
+	w := httptest.NewRecorder()
 
-// 	noteApi := api.NewNoteApi(mockErrorNoteService{})
+	svc := mockNoteService{}
+	svc.ReturnError(errors.New("some weird error"))
+	noteApi := api.NewNoteApi(svc)
 
-// 	noteApi.Get(w, r)
-// 	errResp := parseErrorResponse(w, t)
+	noteApi.Get(w, r)
+	errResp := parseErrorResponse(w, t)
 
-// 	if w.Result().StatusCode != 500 {
-// 		t.Errorf("expected 500 got %v", w.Result().StatusCode)
-// 	}
-// 	if errResp.ErrorText != "An internal server error has occurred." {
-// 		t.Errorf("expected \"An internal server error has occurred.\" got %v", errResp.ErrorText)
-// 	}
-// }
+	if w.Result().StatusCode != 500 {
+		t.Errorf("expected 500 got %v", w.Result().StatusCode)
+	}
+	if errResp.ErrorText != "An internal server error has occurred." {
+		t.Errorf("expected \"An internal server error has occurred.\" got %v", errResp.ErrorText)
+	}
+}
+
+func TestGetNotFoundError(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/1", nil)
+	w := httptest.NewRecorder()
+
+	svc := mockNoteService{}
+	svc.ReturnError(&core.ErrNotFound{})
+	noteApi := api.NewNoteApi(svc)
+
+	noteApi.Get(w, r)
+
+	if w.Result().StatusCode != 404 {
+		t.Errorf("expected 404 got %v", w.Result().StatusCode)
+	}
+}
 
 func TestDelete(t *testing.T) {
 	r := httptest.NewRequest(http.MethodDelete, "/1", nil)
@@ -53,14 +70,23 @@ func TestDelete(t *testing.T) {
 
 	noteApi.Delete(w, r)
 
-	if w.Result().StatusCode != 200 {
-		t.Errorf("expected 500 got %v", w.Result().StatusCode)
+	if w.Result().StatusCode != 204 {
+		t.Errorf("expected 204 got %v", w.Result().StatusCode)
 	}
 }
 
-type mockNoteService struct{}
+type mockNoteService struct {
+	returnError error
+}
+
+func (m *mockNoteService) ReturnError(err error) {
+	m.returnError = err
+}
 
 func (m mockNoteService) Get(context.Context, string) (note.Note, error) {
+	if m.returnError != nil {
+		return note.Note{}, m.returnError
+	}
 	return note.Note{
 		ID:   "1",
 		Data: "somenote",
@@ -68,35 +94,26 @@ func (m mockNoteService) Get(context.Context, string) (note.Note, error) {
 }
 
 func (m mockNoteService) Create(context.Context, note.Note) error {
+	if m.returnError != nil {
+		return m.returnError
+	}
 	return nil
 }
 
 func (m mockNoteService) Delete(context.Context, string) error {
+	if m.returnError != nil {
+		return m.returnError
+	}
 	return nil
 }
 
 func (m mockNoteService) List(ctx context.Context, startIdx, endIdx int) ([]note.ListNote, error) {
+	if m.returnError != nil {
+		return []note.ListNote{}, m.returnError
+	}
 	return []note.ListNote{
 		{ID: "1"},
 	}, nil
-}
-
-type mockErrorNoteService struct{}
-
-func (m mockErrorNoteService) Get(_ context.Context, _ string) (note.Note, error) {
-	return note.Note{}, errors.New("error calling get")
-}
-
-func (m mockErrorNoteService) Create(_ context.Context, _ note.Note) error {
-	return errors.New("error calling create")
-}
-
-func (m mockErrorNoteService) Delete(_ context.Context, _ string) error {
-	return errors.New("error calling delete")
-}
-
-func (m mockErrorNoteService) List(_ context.Context, _, _ int) ([]note.ListNote, error) {
-	return []note.ListNote{}, errors.New("error calling list")
 }
 
 func parseErrorResponse(w *httptest.ResponseRecorder, t *testing.T) api.ErrResponse {

--- a/core/error.go
+++ b/core/error.go
@@ -4,7 +4,7 @@ import "github.com/pkg/errors"
 
 type ErrNotFound struct{}
 
-func (n ErrNotFound) Error() string {
+func (n *ErrNotFound) Error() string {
 	return "not found"
 }
 

--- a/repo/noterepo/repo.go
+++ b/repo/noterepo/repo.go
@@ -75,7 +75,7 @@ func (r *s3Repo) Get(ctx context.Context, id string) (note.Note, error) {
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
 			case s3.ErrCodeNoSuchKey:
-				return note.Note{}, core.ErrNotFound{}
+				return note.Note{}, &core.ErrNotFound{}
 			default:
 				return note.Note{}, err
 			}
@@ -206,7 +206,7 @@ func (r *s3Repo) getIndex(ctx context.Context) ([]note.ListNote, error) {
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
 			case s3.ErrCodeNoSuchKey:
-				return []note.ListNote{}, core.ErrNotFound{}
+				return []note.ListNote{}, &core.ErrNotFound{}
 			default:
 				return []note.ListNote{}, err
 			}


### PR DESCRIPTION
This closes #13 , and #15 

- Added check command in Makefile
- Improved the README
- Revised the task-definition
  - Renamed task def specifically for dev
  - Added entrypoint variables
- Removed unused PROF environment variable from github action
- Upgraded the linter version v1.29 -> v1.43
- Moved to a single mock service that takes an error param
- Cleaned up responses in API
- Properly using pointer in ErrNotFound